### PR TITLE
Bugfix/time report detail

### DIFF
--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/BaseTimeReportDetailFragment.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/BaseTimeReportDetailFragment.kt
@@ -115,12 +115,12 @@ open class BaseTimeReportDetailFragment<T : BaseTimeReportDetailPresenter> : HrA
         toolbarChangeListener.setActionBarTitle(date)
     }
 
-    override fun showProject(project: String) {
-        tvSelectedProject.setText(project)
+    override fun showProject(project: String?) {
+        tvSelectedProject.text = project ?: getString(R.string.tm_hr_time_report_detail_project_empty_error)
     }
 
-    override fun showTask(task: String) {
-        tvSelectedProjectTask.setText(task)
+    override fun showTask(task: String?) {
+        tvSelectedProjectTask.text = task ?: getString(R.string.tm_hr_time_report_detail_task_empty_error)
     }
 
     override fun showDescription(description: String) {

--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/BaseTimeReportDetailFragment.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/BaseTimeReportDetailFragment.kt
@@ -2,6 +2,7 @@ package co.techmagic.hr.presentation.time_tracker.time_report_detail.base
 
 import android.content.Context
 import android.os.Bundle
+import android.support.annotation.StringRes
 import android.text.Editable
 import android.view.LayoutInflater
 import android.view.View
@@ -99,7 +100,7 @@ open class BaseTimeReportDetailFragment<T : BaseTimeReportDetailPresenter> : HrA
         btnStartTimer.setOnClickListener { presenter?.startTimerClicked() }
         btnSave.setOnClickListener { presenter?.saveClicked() }
 
-        edTime.addTextChangedListener(object : TimeInputTextWatcher(edTime){
+        edTime.addTextChangedListener(object : TimeInputTextWatcher(edTime) {
             override fun afterTextChanged(s: Editable?) {
                 super.afterTextChanged(s)
                 presenter?.timeChanged(s.toString())
@@ -116,19 +117,22 @@ open class BaseTimeReportDetailFragment<T : BaseTimeReportDetailPresenter> : HrA
     }
 
     override fun showProject(project: String?) {
-        tvSelectedProject.text = project ?: getString(R.string.tm_hr_time_report_detail_project_empty_error)
+        tvSelectedProject.text = project
+                ?: getString(R.string.tm_hr_time_report_detail_project_empty_error)
     }
 
     override fun showTask(task: String?) {
-        tvSelectedProjectTask.text = task ?: getString(R.string.tm_hr_time_report_detail_task_empty_error)
+        tvSelectedProjectTask.text = task
+                ?: getString(R.string.tm_hr_time_report_detail_task_empty_error)
     }
 
     override fun showDescription(description: String) {
         edDescription.setText(description)
     }
 
-    override fun setDescriptionValid(isValid: Boolean) {
+    override fun setDescriptionValid(isValid: Boolean, @StringRes errorRes: Int?) {
         tvDescriptionError.visibility = if (isValid) View.INVISIBLE else View.VISIBLE
+        errorRes?.let { tvDescriptionError.setText(errorRes) }
         setBackgroundByValid(edDescription, isValid)
     }
 

--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/HrAppBaseTimeReportDetailPresenter.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/HrAppBaseTimeReportDetailPresenter.kt
@@ -104,11 +104,11 @@ abstract class HrAppBaseTimeReportDetailPresenter<T : BaseTimeReportDetailView>(
     abstract fun makeSaveRequest()
 
     private fun showProject() {
-        view?.showProject(projectViewModel?.title ?: "")
+        view?.showProject(projectViewModel?.title)
     }
 
     private fun showProjectTask() {
-        view?.showTask(projectTaskViewModel?.task?.name ?: "")
+        view?.showTask(projectTaskViewModel?.task?.name)
     }
 
     private fun getFormattedDate() = reportDate.formatDate(TOOLBAR_DATE_FORMAT)

--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/HrAppBaseTimeReportDetailPresenter.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/HrAppBaseTimeReportDetailPresenter.kt
@@ -57,7 +57,11 @@ abstract class HrAppBaseTimeReportDetailPresenter<T : BaseTimeReportDetailView>(
     }
 
     override fun changeTaskClicked() {
-        router?.openSelectTask(projectViewModel?.id ?: "")
+        if (projectViewModel != null) {
+            router?.openSelectTask(projectViewModel?.id ?: "")
+        } else {
+            view?.setProjectValid(false)
+        }
     }
 
     override fun descriptionChanged(description: String) {

--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/HrAppBaseTimeReportDetailPresenter.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/HrAppBaseTimeReportDetailPresenter.kt
@@ -104,7 +104,7 @@ abstract class HrAppBaseTimeReportDetailPresenter<T : BaseTimeReportDetailView>(
     abstract fun makeSaveRequest()
 
     private fun showProject() {
-        view?.showProject(projectViewModel?.title)
+        view?.showProject(projectViewModel?.title ?: null)
     }
 
     private fun showProjectTask() {

--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/HrAppBaseTimeReportDetailPresenter.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/HrAppBaseTimeReportDetailPresenter.kt
@@ -1,5 +1,6 @@
 package co.techmagic.hr.presentation.time_tracker.time_report_detail.base
 
+import co.techmagic.hr.R
 import co.techmagic.hr.domain.repository.TimeReportRepository
 import co.techmagic.hr.presentation.pojo.ProjectTaskViewModel
 import co.techmagic.hr.presentation.pojo.ProjectViewModel
@@ -16,8 +17,10 @@ abstract class HrAppBaseTimeReportDetailPresenter<T : BaseTimeReportDetailView>(
         BaseTimeReportDetailPresenter {
 
     companion object {
-        const val RATE = 12 //FYI 25 MAY 2019: this value is hardcoded; I don`t now why, but it is OK for now
+        const val RATE = 12 //FYI 25 MAY 2019: this value is hardcoded; I don`t now why we should send it in the request, but it is OK for now
+        const val MAX_DESCRIPTION_LENGTH = 600
     }
+
 
     lateinit var reportDate: Calendar
     var projectViewModel: ProjectViewModel? = null
@@ -122,11 +125,23 @@ abstract class HrAppBaseTimeReportDetailPresenter<T : BaseTimeReportDetailView>(
         view?.showTime(TimeFormatUtil.formatMinutesToHours(timeInMinutes))
     }
 
-    protected fun validateDescription() = view?.setDescriptionValid(isDescriptionValid())
+    protected fun validateDescription() {
+        val errorRes = when {
+            isDescriptionLengthLongerThanMax() -> R.string.tm_hr_time_report_detail_description_tool_long_error
+            isDescriptionEmpty() -> R.string.tm_hr_time_report_detail_description_empty_error
+            else -> null
+        }
+
+        view?.setDescriptionValid(isDescriptionValid(), errorRes)
+    }
+
     protected fun validateProject() = view?.setProjectValid(isProjectValid())
     protected fun validateProjectTask() = view?.setTaskValid(isProjectTaskValid())
 
-    protected fun isDescriptionValid() = !description.isEmpty()
+    protected fun isDescriptionValid() = !isDescriptionEmpty() && !isDescriptionLengthLongerThanMax()
     protected fun isProjectValid() = projectViewModel != null
     protected fun isProjectTaskValid() = projectTaskViewModel != null
+
+    protected fun isDescriptionEmpty() = description.isEmpty()
+    protected fun isDescriptionLengthLongerThanMax() = description.length > MAX_DESCRIPTION_LENGTH
 }

--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/TimeReportDetailContract.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/TimeReportDetailContract.kt
@@ -7,8 +7,8 @@ import com.techmagic.viper.View
 interface BaseTimeReportDetailView : View, ProgressableView {
     fun setDeleteReportButtonVisible(visible : Boolean)
     fun showDate(date: String)
-    fun showProject(project: String)
-    fun showTask(task: String)
+    fun showProject(project: String?)
+    fun showTask(task: String?)
     fun showDescription(description: String)
     fun setDescriptionValid(enabled: Boolean)
     fun setProjectValid(isValid: Boolean)

--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/TimeReportDetailContract.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/time_report_detail/base/TimeReportDetailContract.kt
@@ -1,5 +1,6 @@
 package co.techmagic.hr.presentation.time_tracker.time_report_detail.base
 
+import android.support.annotation.StringRes
 import co.techmagic.hr.presentation.mvp.base.ProgressableView
 import com.techmagic.viper.Presenter
 import com.techmagic.viper.View
@@ -10,7 +11,7 @@ interface BaseTimeReportDetailView : View, ProgressableView {
     fun showProject(project: String?)
     fun showTask(task: String?)
     fun showDescription(description: String)
-    fun setDescriptionValid(enabled: Boolean)
+    fun setDescriptionValid(enabled: Boolean, @StringRes errorRes : Int?)
     fun setProjectValid(isValid: Boolean)
     fun setTaskValid(isValid: Boolean)
     fun showTime(formattedTime : String)

--- a/app/src/main/java/co/techmagic/hr/presentation/util/TimeInputTextWatcher.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/util/TimeInputTextWatcher.kt
@@ -8,7 +8,7 @@ open class TimeInputTextWatcher constructor(val editText: EditText) : SimpleText
     private var isInnerChange = false
 
     init {
-        editText.setText(TIME_SEPARATOR)
+       // editText.setText(TIME_SEPARATOR)
     }
 
     companion object {
@@ -37,6 +37,7 @@ open class TimeInputTextWatcher constructor(val editText: EditText) : SimpleText
             if (!text.contains(TIME_SEPARATOR)) {
                 text = text.substring(0, editText.selectionEnd) + ":" + text.substring(editText.selectionEnd, text.length)
                 s.replace(0, s.length, text)
+                editText.setSelection(s.indexOf(TIME_SEPARATOR))
             } else if (!isTextValid(text, hours, minutes)) {
 
                 if (hours > MAX_HOURS) {

--- a/app/src/main/java/co/techmagic/hr/presentation/util/ViewExtentions.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/util/ViewExtentions.kt
@@ -25,9 +25,10 @@ fun View.changeShapeStrokeColor(@DimenRes strokeWidth: Int, @ColorRes colorRes: 
     } else {
         throw IllegalArgumentException()
     }
-    drawable.setStroke(
+
+    val newDrawable = drawable.mutate() as GradientDrawable
+    newDrawable.setStroke(
             resources.getDimensionPixelOffset(strokeWidth),
-            ContextCompat.getColor(context, colorRes)
-    )
-    drawable.mutate()
+            ContextCompat.getColor(context, colorRes))
+    background = drawable
 }

--- a/app/src/main/res/layout/fragment_time_report_detail.xml
+++ b/app/src/main/res/layout/fragment_time_report_detail.xml
@@ -60,7 +60,7 @@
             <TextView
                 android:id="@+id/tvTimeReportDetailDescriptionError"
                 style="@style/ErrorFieldTextViewStyle"
-                android:text="@string/tm_hr_time_report_detail_description_empty_error"
+                tools:text="@string/tm_hr_time_report_detail_description_empty_error"
                 tools:visibility="visible" />
 
             <TextView

--- a/app/src/main/res/layout/fragment_time_report_detail.xml
+++ b/app/src/main/res/layout/fragment_time_report_detail.xml
@@ -28,6 +28,7 @@
 
             <TextView
                 android:id="@+id/tvTimeReportDetailSelectedProject"
+                android:text="@string/tm_hr_time_report_detail_project_empty_error"
                 style="@style/TimeReportPickerTextStyle" />
 
             <TextView
@@ -42,6 +43,7 @@
 
             <TextView
                 android:id="@+id/tvTimeReportDetailSelectedTask"
+                android:text="@string/tm_hr_time_report_detail_task_empty_error"
                 style="@style/TimeReportPickerTextStyle" />
 
             <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,7 @@
     <string name="tm_hr_time_report_detail_task_header">Task</string>
     <string name="tm_hr_time_report_detail_description_hint">Task description</string>
     <string name="tm_hr_time_report_detail_description_empty_error">Description is required!</string>
+    <string name="tm_hr_time_report_detail_description_tool_long_error">Max size - 600!</string>
     <string name="tm_hr_time_report_detail_project_empty_error">Please select a project</string>
     <string name="tm_hr_time_report_detail_task_empty_error">Please select a task</string>
     <string name="tm_hr_time_report_detail_time_spent_header">Time spent</string>


### PR DESCRIPTION
https://trello.com/c/L5BX10cX/33-invalid-placeholder-for-the-time-on-create-edit-report-screen
https://trello.com/c/FRnjSDA5/34-placeholders-are-missing-for-project-task-fields-on-create-report-screen
https://trello.com/c/fQowIRNF/38-create-edit-report-no-error-is-displayed-in-case-a-description-is-longer-than-600-characters
https://trello.com/c/TgmM5fgD/36-create-report-400-error-is-displayed-if-a-user-selects-a-taks-before-the-project
https://trello.com/c/pUIXyu0k/35-error-state-is-preserved-if-you-open-and-close-create-report-screen