### PR TITLE
Fix displaying notification after app kill

### DIFF
--- a/app/src/main/java/co/techmagic/hr/device/time_tracker/tracker_service/HrAppTimeTrackerService.kt
+++ b/app/src/main/java/co/techmagic/hr/device/time_tracker/tracker_service/HrAppTimeTrackerService.kt
@@ -118,6 +118,7 @@ class HrAppTimeTrackerService : Service(), TimeTracker {
 
     override fun close() {
         stopForeground(true)
+        stopSelf()
         trackingReportOrigin = null
         trackingReport = null
     }


### PR DESCRIPTION
https://trello.com/c/anVLruUi/62-empty-push-is-received-after-stopping-the-timer-and-killing-the-app