### PR TITLE
Bugfix/empty day data

### DIFF
--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/HrAppTimeTrackerPresenter.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/HrAppTimeTrackerPresenter.kt
@@ -50,7 +50,7 @@ class HrAppTimeTrackerPresenter(
 
         call(timeTrackerInteractor.isRunning(), {
             it.report?.date?.toCalendar()?.let { date ->
-                onDateSelected(date)
+                onDateSelected(date.dateOnly())
             }
         })
     }

--- a/app/src/main/java/co/techmagic/hr/presentation/time_tracker/HrAppTimeTrackerPresenter.kt
+++ b/app/src/main/java/co/techmagic/hr/presentation/time_tracker/HrAppTimeTrackerPresenter.kt
@@ -117,8 +117,9 @@ class HrAppTimeTrackerPresenter(
                         val weekReports = response.reports.map { userReportViewMadelMapper.transform(it) }
                         initWeekCache(date)
                         for (report in weekReports) {
-                            cache[key(report.date.toCalendar())]?.add(report)
-                            view?.notifyDayReportsChanged(date)
+                            val reportDate = report.date.toCalendar();
+                            cache[key(reportDate)]?.add(report)
+                            view?.notifyDayReportsChanged(reportDate)
                             if (runningReport?.id?.equals(report.id) == true) {
                                 checkLoadedReportForTracking(report)
                             }


### PR DESCRIPTION
https://trello.com/c/aUP7dDuh/82-empty-day-view-is-displayed-after-deleting-the-report-with-timer-on